### PR TITLE
add IP SAN to CSR when we're adding the DNS SAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ In order for your application to be able to get configured through the SDK, it n
 |:--------------------------|:----------:|:------------- 
 |`DSH_SECRET_TOKEN`         | yes        | The DSH _secret_ needed to register the application with the PKI service.
 |`DSH_CA_CERTIFICATE`       | yes        | The DSH specific CA Certificate to sign against.
-|`KAFKA_CONFIG_HOST`        | yes        | The PKI service connection string
+|`DSH_KAFKA_CONFIG_ENDPOINT`| yes        | The PKI service connection string
 |`MESOS_TASK_ID`            | yes        | The task ID assigned to the application instance
 |`MARATHON_APP_ID`          | yes        | The unique application ID for your application
 |`DSH_CONTAINER_DNS_NAME`   | yes        | When serving, the DNS name

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.kpn-dsh</groupId>
   <artifactId>platform-sdk-java</artifactId>
-  <version>0.2.2</version>
+  <version>0.2.3-SNAPSHOT</version>
   <name>dsh-platform-sdk</name>
   <description>The Data Serviceshub (DSH) Platform SDK facilitates easier development of applications on the DSH. It abstracts over the authentication and configuration of your Kafka clients against the policies of the DSH.</description>
   <url>https://github.com/kpn-dsh/dsh-sdk-platform-java</url>

--- a/src/main/java/dsh/sdk/Sdk.java
+++ b/src/main/java/dsh/sdk/Sdk.java
@@ -69,12 +69,12 @@ public class Sdk {
     private static final Logger logger = LoggerFactory.getLogger(Sdk.class);
 
     //TODO: make these configurable, together with a function "how" to extract the needed info from the variable (regex?)
-    private static final String DSH_SECRET_TOKEN        = "DSH_SECRET_TOKEN";       // String -- mandatory (not empty)
-    private static final String DSH_CA_CERTIFICATE      = "DSH_CA_CERTIFICATE";     // String -- mandatory (valid cert.)
-    private static final String KAFKA_CONFIG_HOST       = "KAFKA_CONFIG_HOST";      // String -- optional (valid URL) -- mandatory for KafkaParser/StreamsParser
-    private static final String MESOS_TASK_ID           = "MESOS_TASK_ID";          // String -- mandatory (regex)
-    private static final String MARATHON_APP_ID         = "MARATHON_APP_ID";        // String -- mandatory (regex)
-    private static final String DSH_CONTAINER_DNS_NAME  = "DSH_CONTAINER_DNS_NAME"; // String -- mandatory (???)
+    private static final String DSH_SECRET_TOKEN          = "DSH_SECRET_TOKEN";           // String -- mandatory (not empty)
+    private static final String DSH_CA_CERTIFICATE        = "DSH_CA_CERTIFICATE";         // String -- mandatory (valid cert.)
+    private static final String DSH_KAFKA_CONFIG_ENDPOINT = "DSH_KAFKA_CONFIG_ENDPOINT";  // String -- optional (valid URL) -- mandatory for KafkaParser/StreamsParser
+    private static final String MESOS_TASK_ID             = "MESOS_TASK_ID";              // String -- mandatory (regex)
+    private static final String MARATHON_APP_ID           = "MARATHON_APP_ID";            // String -- mandatory (regex)
+    private static final String DSH_CONTAINER_DNS_NAME    = "DSH_CONTAINER_DNS_NAME";     // String -- mandatory (???)
 
     // fetch the value of a system property -- throw IllegalArgument Exception when not found or empty
     private static String getEnvOrThrow(String key) {
@@ -105,7 +105,7 @@ public class Sdk {
             try {
                 token = getEnvOrThrow(DSH_SECRET_TOKEN);
                 caCert = SslUtils.certificateFromPEM(getEnvOrThrow(DSH_CA_CERTIFICATE));
-                pkiHost = getEnvOrThrow(KAFKA_CONFIG_HOST);
+                pkiHost = getEnvOrThrow(DSH_KAFKA_CONFIG_ENDPOINT);
                 taskId = getEnvOrThrow(MESOS_TASK_ID);
                 appId = AppId.from(getEnvOrThrow(MARATHON_APP_ID));
                 dnsName = getEnvOrThrow(DSH_CONTAINER_DNS_NAME);

--- a/src/main/java/dsh/sdk/internal/AppId.java
+++ b/src/main/java/dsh/sdk/internal/AppId.java
@@ -64,7 +64,7 @@ public class AppId {
     public Set<String> groups() { return new HashSet<>(Arrays.asList(groupsFromAppId(appId))); }
 
     /**
-     * The root-node of the group-chain the application resides in.
+     * The root node of the group-chain the application resides in.
      * (is equal to the tenant network)
      *
      * @return root node of the group-chain (= tenant identifier)


### PR DESCRIPTION
If the SDK builder is configured to include the DNS name in the certificate, also include the IP address.
This makes it possible to use the acquired certificate as a server certificate for SSL communication with the platform's reverse proxy.